### PR TITLE
Add field memory: remember field-label to profile mappings across sites

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -25,8 +25,93 @@ const DEFAULT_PROFILE_V2 = {
 const STORAGE_KEYS = {
   profileV2: "profileV2",
   apiConfig: "apiConfig",
-  updateState: "updateState"
+  updateState: "updateState",
+  fieldMemoryV1: "fieldMemoryV1"
 };
+
+const MAX_FIELD_MEMORY_ENTRIES = 500;
+
+function createDefaultFieldMemory() {
+  return { enabled: true, entries: {} };
+}
+
+async function getFieldMemory() {
+  const values = await chrome.storage.local.get([STORAGE_KEYS.fieldMemoryV1]);
+  const store = values[STORAGE_KEYS.fieldMemoryV1];
+  if (!store || typeof store !== "object" || !store.entries || typeof store.entries !== "object") {
+    return createDefaultFieldMemory();
+  }
+  return { enabled: store.enabled !== false, entries: store.entries };
+}
+
+async function saveFieldMemory(store) {
+  await chrome.storage.local.set({ [STORAGE_KEYS.fieldMemoryV1]: store });
+}
+
+async function recordFieldMemory(payload = {}) {
+  const items = Array.isArray(payload.items) ? payload.items : [];
+  const store = await getFieldMemory();
+  if (!store.enabled) {
+    return store;
+  }
+  const now = Date.now();
+  for (const item of items) {
+    const key = normalizeMemoryKey(item?.key);
+    const sourcePath = typeof item?.sourcePath === "string" ? item.sourcePath : "";
+    if (!key || !sourcePath) {
+      continue;
+    }
+    const previous = store.entries[key];
+    store.entries[key] = {
+      key,
+      sourcePath,
+      fieldLabel: String(item.fieldLabel || key).slice(0, 80),
+      sourceLabel: String(item.sourceLabel || "").slice(0, 120),
+      hostname: String(item.hostname || "").slice(0, 120),
+      mappingSource: String(item.mappingSource || "").slice(0, 40),
+      hits: Number.isFinite(previous?.hits) ? previous.hits + 1 : 1,
+      updatedAt: now
+    };
+  }
+  const keys = Object.keys(store.entries);
+  if (keys.length > MAX_FIELD_MEMORY_ENTRIES) {
+    keys
+      .sort((a, b) => (store.entries[a].updatedAt || 0) - (store.entries[b].updatedAt || 0))
+      .slice(0, keys.length - MAX_FIELD_MEMORY_ENTRIES)
+      .forEach((staleKey) => {
+        delete store.entries[staleKey];
+      });
+  }
+  await saveFieldMemory(store);
+  return store;
+}
+
+async function deleteFieldMemory(payload = {}) {
+  const store = await getFieldMemory();
+  const key = normalizeMemoryKey(payload?.key);
+  if (key) {
+    delete store.entries[key];
+  }
+  await saveFieldMemory(store);
+  return store;
+}
+
+async function clearFieldMemory() {
+  const store = createDefaultFieldMemory();
+  await saveFieldMemory(store);
+  return store;
+}
+
+async function setFieldMemoryEnabled(payload = {}) {
+  const store = await getFieldMemory();
+  store.enabled = Boolean(payload.enabled);
+  await saveFieldMemory(store);
+  return store;
+}
+
+function normalizeMemoryKey(value) {
+  return String(value || "").trim().slice(0, 160);
+}
 
 const PROFILE_PANEL_STATE_KEY = "OJAF_PROFILE_PANEL_STATE";
 const MAX_PROFILE_PANEL_STATE_ITEMS = 20;
@@ -118,6 +203,16 @@ async function handleMessage(message) {
       return listModels(message.payload || {});
     case "OJAF_TEST_CONNECTION":
       return testApi(message.payload || {});
+    case "OJAF_GET_FIELD_MEMORY":
+      return getFieldMemory();
+    case "OJAF_RECORD_FIELD_MEMORY":
+      return recordFieldMemory(message.payload || {});
+    case "OJAF_DELETE_FIELD_MEMORY":
+      return deleteFieldMemory(message.payload || {});
+    case "OJAF_CLEAR_FIELD_MEMORY":
+      return clearFieldMemory();
+    case "OJAF_SET_FIELD_MEMORY_ENABLED":
+      return setFieldMemoryEnabled(message.payload || {});
     case "OJAF_GET_UPDATE_STATUS":
       return getUpdateState();
     case "OJAF_CHECK_FOR_UPDATE":

--- a/src/content.js
+++ b/src/content.js
@@ -5352,6 +5352,7 @@
       ok: true,
       learned: learned.length,
       ambiguousCount: ambiguous.length,
+      ambiguousLabels: ambiguous.slice(0, 5),
       notInProfileCount: new Set(notInProfile).size,
       notInProfileLabels: Array.from(new Set(notInProfile)).slice(0, 8),
       skippedRepeat,

--- a/src/content.js
+++ b/src/content.js
@@ -5130,6 +5130,236 @@
     return Number(rightCandidate.score || 0) - Number(leftCandidate.score || 0);
   }
 
+  // ===== 字段记忆（本地增强）：记住“页面字段 → 资料字段”的成功映射，下次直接回填 =====
+  // 隐私边界与项目一致：只存字段名与资料字段路径，不存任何资料值。
+
+  async function loadFieldMemoryStore() {
+    try {
+      const store = await sendRuntimeMessage({ type: "OJAF_GET_FIELD_MEMORY" });
+      if (!store || typeof store !== "object" || !store.entries || typeof store.entries !== "object") {
+        return null;
+      }
+      return store;
+    } catch {
+      return null;
+    }
+  }
+
+  function buildFieldMemoryKey(fieldLabel, fieldCategory) {
+    const labelKey = normalizeMatchKey(fieldLabel);
+    if (!labelKey) {
+      return "";
+    }
+    return `${fieldCategory || "未分类"}|${labelKey}`;
+  }
+
+  function countScanFieldOccurrences(scan) {
+    const totals = new Map();
+    for (const field of (Array.isArray(scan?.fields) ? scan.fields : [])) {
+      if (!field?.canFill) {
+        continue;
+      }
+      const label = field.inferredLabel || inferFieldLabel(field);
+      const category = field.inferredCategory || inferMatchSection(field);
+      const key = buildFieldMemoryKey(label, category) || `${field.fieldId}`;
+      totals.set(key, (totals.get(key) || 0) + 1);
+    }
+    return totals;
+  }
+
+  // 只在本页同名标签唯一时才使用/写入记忆，避免“学校/开始时间”这类多实例字段被错误复用。
+  async function mergeFieldMemoryIntoPlan(plan) {
+    if (!plan || !Array.isArray(plan.candidates) || !Array.isArray(plan.scan?.fields)) {
+      return plan;
+    }
+    const memoryStore = await loadFieldMemoryStore();
+    if (!memoryStore || memoryStore.enabled === false || Object.keys(memoryStore.entries).length === 0) {
+      return plan;
+    }
+    const totals = countScanFieldOccurrences(plan.scan);
+    const matchedFieldIds = new Set(plan.candidates.map((candidate) => candidate?.fieldId).filter(Boolean));
+    const entries = Array.isArray(plan.entries) ? plan.entries : getCurrentProfileEntries();
+    const memoryCandidates = [];
+
+    for (const field of plan.scan.fields) {
+      if (!field?.canFill || matchedFieldIds.has(field.fieldId)) {
+        continue;
+      }
+      const fieldLabel = field.inferredLabel || inferFieldLabel(field);
+      const fieldCategory = field.inferredCategory || inferMatchSection(field);
+      const key = buildFieldMemoryKey(fieldLabel, fieldCategory);
+      if (!key || (totals.get(key) || 0) > 1) {
+        continue;
+      }
+      const record = memoryStore.entries[key];
+      if (!record?.sourcePath) {
+        continue;
+      }
+      const candidate = createAiAutofillCandidate(
+        {
+          fieldId: field.fieldId,
+          sourcePath: record.sourcePath,
+          confidence: 0.95,
+          reason: `字段记忆：曾在 ${record.hostname || "之前的页面"} 匹配成功`
+        },
+        plan.scan,
+        entries
+      );
+      if (!candidate) {
+        continue;
+      }
+      candidate.mappingSource = "字段记忆";
+      memoryCandidates.push(candidate);
+    }
+
+    if (memoryCandidates.length === 0) {
+      return plan;
+    }
+
+    const candidates = [...plan.candidates, ...memoryCandidates].sort(compareAutofillCandidates);
+    const autoFillIds = new Set(plan.autoFillIds || []);
+    for (const candidate of memoryCandidates) {
+      if (candidate.shouldAutoFill) {
+        autoFillIds.add(candidate.id);
+      }
+    }
+    return {
+      ...plan,
+      candidates,
+      autoFillIds,
+      memoryCount: memoryCandidates.length
+    };
+  }
+
+  async function recordFieldMemoryFromFillResults(plan, filledCandidates, results) {
+    try {
+      const items = [];
+      const byId = new Map((filledCandidates || []).map((candidate) => [candidate?.id, candidate]));
+      const totals = countScanFieldOccurrences(plan?.scan);
+      const hostname = plan?.page?.hostname || location.hostname || "";
+      for (const result of (results || [])) {
+        if (!result?.ok) {
+          continue;
+        }
+        const candidate = byId.get(result.id);
+        if (!candidate?.sourceItemId || !candidate.fieldLabel) {
+          continue;
+        }
+        const key = buildFieldMemoryKey(candidate.fieldLabel, candidate.fieldCategory);
+        if (!key || (totals.get(key) || 0) > 1) {
+          continue;
+        }
+        items.push({
+          key,
+          sourcePath: candidate.sourceItemId,
+          fieldLabel: candidate.fieldLabel,
+          sourceLabel: candidate.sourceLabel || "",
+          hostname,
+          mappingSource: candidate.mappingSource || ""
+        });
+      }
+      if (items.length === 0) {
+        return 0;
+      }
+      await sendRuntimeMessage({ type: "OJAF_RECORD_FIELD_MEMORY", payload: { items } });
+      return items.length;
+    } catch {
+      return 0;
+    }
+  }
+
+  // 从本页学习：用户手动填好的字段，反查资料库，把“字段标签 → 资料字段”写进记忆。
+  async function learnFromPage() {
+    await refreshCurrentProfile({ force: true });
+    const entries = getCurrentProfileEntries().filter((entry) => entry?.hasValue);
+    if (entries.length === 0) {
+      return { ok: false, reason: "资料库为空：请先在设置页导入或填写资料，再使用从本页学习。" };
+    }
+    const scan = await scanForm();
+    const hostname = scan?.hostname || location.hostname || "";
+    const totals = countScanFieldOccurrences(scan);
+    const fields = (Array.isArray(scan?.fields) ? scan.fields : []).filter((field) => field?.canFill && field?.hasCurrentValue);
+    const learned = [];
+    const ambiguous = [];
+    const notInProfile = [];
+    let skippedRepeat = 0;
+
+    for (const field of fields) {
+      const fieldLabel = field.inferredLabel || inferFieldLabel(field);
+      const fieldCategory = field.inferredCategory || inferMatchSection(field);
+      const key = buildFieldMemoryKey(fieldLabel, fieldCategory);
+      if (!key || (totals.get(key) || 0) > 1) {
+        skippedRepeat += 1;
+        continue;
+      }
+      const sensitiveText = compactText([fieldLabel, field.placeholder, field.name, field.id].join(" "));
+      if (/上传|附件|照片|证件照|简历附件|密码/.test(sensitiveText)) {
+        continue;
+      }
+
+      const valueMatches = entries.filter((entry) => valuesLookEquivalent(field.currentValue, entry.value));
+      if (valueMatches.length === 0) {
+        notInProfile.push(fieldLabel || field.fieldId);
+        continue;
+      }
+
+      let chosen = valueMatches[0];
+      if (valueMatches.length > 1) {
+        let bestScore = -9999;
+        for (const entry of valueMatches) {
+          const score = scoreAutofillCandidate(field, entry, fieldLabel, fieldCategory);
+          if (score > bestScore) {
+            bestScore = score;
+            chosen = entry;
+          }
+        }
+        if (bestScore < 18) {
+          ambiguous.push(fieldLabel || field.fieldId);
+          continue;
+        }
+      }
+
+      learned.push({
+        key,
+        sourcePath: chosen.itemId,
+        fieldLabel: fieldLabel || key,
+        sourceLabel: chosen.label || "",
+        hostname,
+        mappingSource: "从本页学习"
+      });
+      const element = await resolveFieldElement(field);
+      if (element) {
+        markElement(element, "filled", `已学习: ${fieldLabel || ""} → ${chosen.label || ""}`);
+      }
+    }
+
+    if (learned.length === 0) {
+      return {
+        ok: true,
+        learned: 0,
+        ambiguousCount: ambiguous.length,
+        ambiguousLabels: ambiguous.slice(0, 5),
+        notInProfileCount: new Set(notInProfile).size,
+        notInProfileLabels: Array.from(new Set(notInProfile)).slice(0, 8),
+        skippedRepeat,
+        scannedWithValue: fields.length,
+        message: "没有学到新映射：页面上有值的字段要么已重复学习，要么值不在资料库里。"
+      };
+    }
+
+    await sendRuntimeMessage({ type: "OJAF_RECORD_FIELD_MEMORY", payload: { items: learned } });
+    return {
+      ok: true,
+      learned: learned.length,
+      ambiguousCount: ambiguous.length,
+      notInProfileCount: new Set(notInProfile).size,
+      notInProfileLabels: Array.from(new Set(notInProfile)).slice(0, 8),
+      skippedRepeat,
+      scannedWithValue: fields.length,
+      message: `已学习 ${learned.length} 条字段映射。`
+    };
+  }
+
   function buildAutofillPlan(scan) {
     const entries = getCurrentProfileEntries();
     const visibleFields = Array.isArray(scan?.fields) ? scan.fields.filter((field) => field && field.canFill) : [];
@@ -5429,15 +5659,18 @@
         };
       }
 
+      plan = await mergeFieldMemoryIntoPlan(plan);
+      const memoryNote = plan.memoryCount > 0 ? `，字段记忆补齐 ${plan.memoryCount} 项` : "";
+
       const aiUsage = getAutofillAiSnapshot();
       const aiStatus = aiUsage.message;
-      setAutofillProgress("整理匹配结果", 90, `${buildPlanMatchSummary(plan)}，共匹配 ${plan.candidates.length} 项`);
+      setAutofillProgress("整理匹配结果", 90, `${buildPlanMatchSummary(plan)}，共匹配 ${plan.candidates.length} 项${memoryNote}`);
       updateAutofillDebugPlan(plan, { aiStatus, aiUsage });
 
       const autoFillCount = plan.autoFillIds.size;
       setProfilePanelStatus(
         plan.candidates.length > 0
-          ? `${aiStatus} ${buildPlanMatchSummary(plan)}，共匹配 ${plan.candidates.length} 项，将自动填写 ${autoFillCount} 项。`
+          ? `${aiStatus} ${buildPlanMatchSummary(plan)}，共匹配 ${plan.candidates.length} 项，将自动填写 ${autoFillCount} 项${memoryNote}。`
           : `${aiStatus} 没有找到可自动匹配的字段。`
       );
       setAutofillProgress("匹配完成", 90, `${buildPlanMatchSummary(plan)}，准备自动填写当前网页`);
@@ -5596,6 +5829,7 @@
 
     const filledCount = results.filter((result) => result.ok).length;
     const failedCount = results.length - filledCount;
+    void recordFieldMemoryFromFillResults(plan, autoFillCandidates, results);
     const skippedCount = await markDeferredPlanCandidates(plan, autoFillSet);
     const summary = {
       attempted: results.length,
@@ -6578,6 +6812,10 @@
 
     if (message.type === "OJAF_START_AUTOFILL") {
       return runOneClickAutofill();
+    }
+
+    if (message.type === "OJAF_LEARN_FROM_PAGE") {
+      return learnFromPage();
     }
 
     if (message.type === "OJAF_GET_RUNTIME_STATE") {

--- a/src/content.js
+++ b/src/content.js
@@ -5275,6 +5275,9 @@
     if (entries.length === 0) {
       return { ok: false, reason: "资料库为空：请先在设置页导入或填写资料，再使用从本页学习。" };
     }
+    // 先清掉上一次填写/学习留下的标记，让页面只显示本次结果，
+    // 避免旧橙标残留让人误以为更新没生效。
+    clearMarks();
     const scan = await scanForm();
     const hostname = scan?.hostname || location.hostname || "";
     const totals = countScanFieldOccurrences(scan);

--- a/src/content.js
+++ b/src/content.js
@@ -5305,18 +5305,33 @@
 
       let chosen = valueMatches[0];
       if (valueMatches.length > 1) {
+        // 值全等优先：valuesLookEquivalent 的包含式匹配会让长文本（如自我描述包含姓名）
+        // 混进候选；先按归一化后完全相等筛选，伪匹配直接出局。
+        const exactMatches = valueMatches.filter((entry) => {
+          const left = normalizeComparableValue(field.currentValue);
+          const right = normalizeComparableValue(entry.value);
+          return Boolean(left && right && left === right);
+        });
+        const pool = exactMatches.length > 0 ? exactMatches : valueMatches;
         let bestScore = -9999;
-        for (const entry of valueMatches) {
+        let bestEntry = null;
+        for (const entry of pool) {
           const score = scoreAutofillCandidate(field, entry, fieldLabel, fieldCategory);
           if (score > bestScore) {
             bestScore = score;
-            chosen = entry;
+            bestEntry = entry;
           }
         }
-        if (bestScore < 18) {
+        if (!bestEntry || bestScore <= 0) {
+          // 全部被语义门槛挡住（类别冲突等），宁可不学
           ambiguous.push(fieldLabel || field.fieldId);
           continue;
         }
+        if (pool.length > 1 && bestScore < 18) {
+          ambiguous.push(fieldLabel || field.fieldId);
+          continue;
+        }
+        chosen = bestEntry;
       }
 
       learned.push({

--- a/src/options.html
+++ b/src/options.html
@@ -81,6 +81,19 @@
 
       <section class="grid settings-grid">
         <section class="card update-card">
+          <h2>字段记忆（本机增强）</h2>
+          <p class="hint">自动填写成功后，会把“页面字段 → 资料字段”的对应关系记在本机；下次遇到同名字段直接回填，不再依赖 AI。只记字段名和资料字段路径，不记资料值。同页出现多次的字段（如多条教育经历的“学校”）不会使用记忆。</p>
+          <div class="actions">
+            <label style="display:inline-flex;align-items:center;gap:6px;">
+              <input id="fieldMemoryEnabled" type="checkbox" /> 启用字段记忆
+            </label>
+            <button id="clearFieldMemory" class="ghost danger" type="button">清空记忆</button>
+          </div>
+          <p id="fieldMemoryFeedback" class="update-feedback" aria-live="polite">正在读取字段记忆...</p>
+          <ul id="fieldMemoryList" style="list-style:none;margin:8px 0 0;padding:0;max-height:220px;overflow:auto;font-size:12px;"></ul>
+        </section>
+
+        <section class="card update-card">
           <h2>版本更新</h2>
           <p class="hint">插件会定期检查 GitHub Release。发现新版本时，浏览器图标会显示 NEW；更新前建议先导出资料备份。更新时不要卸载扩展，覆盖或重新加载后，本机资料和 API 设置会保留。</p>
           <div class="actions">

--- a/src/options.js
+++ b/src/options.js
@@ -26,6 +26,10 @@ const fields = {
   checkUpdateButton: document.getElementById("checkUpdate"),
   openUpdateButton: document.getElementById("openUpdatePage"),
   updateFeedback: document.getElementById("updateFeedback"),
+  fieldMemoryEnabled: document.getElementById("fieldMemoryEnabled"),
+  fieldMemoryList: document.getElementById("fieldMemoryList"),
+  fieldMemoryFeedback: document.getElementById("fieldMemoryFeedback"),
+  clearFieldMemoryButton: document.getElementById("clearFieldMemory"),
   toast: document.getElementById("toast"),
   status: document.getElementById("status")
 };
@@ -505,6 +509,103 @@ window.addEventListener("resize", scheduleProfileSectionSync);
 
 loadSettings();
 loadUpdateStatus();
+initFieldMemoryCard();
+
+// ===== 字段记忆管理（本机增强） =====
+async function getFieldMemory() {
+  try {
+    return await sendRuntimeMessage({ type: "OJAF_GET_FIELD_MEMORY" });
+  } catch (error) {
+    return { enabled: true, entries: {}, error: error.message };
+  }
+}
+
+function renderFieldMemoryList(store) {
+  if (!fields.fieldMemoryList) {
+    return;
+  }
+  const entries = Object.values(store?.entries || {}).sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+  if (entries.length === 0) {
+    fields.fieldMemoryList.innerHTML = `<li class="hint">还没有记忆。第一次自动填写成功后会自动积累。</li>`;
+    return;
+  }
+  fields.fieldMemoryList.innerHTML = entries.slice(0, 100).map((entry) => {
+    const date = entry.updatedAt ? new Date(entry.updatedAt).toLocaleString("zh-CN", { month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" }) : "";
+    return `
+      <li style="display:flex;gap:8px;align-items:center;padding:4px 0;border-bottom:1px solid rgba(127,127,127,.15);">
+        <span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escapeHtml(entry.key)}">
+          <strong>${escapeHtml(entry.fieldLabel || entry.key.split("|").pop() || "")}</strong>
+          <span class="hint"> → ${escapeHtml(entry.sourceLabel || entry.sourcePath || "")}</span>
+        </span>
+        <span class="hint" style="white-space:nowrap;">${escapeHtml(entry.hostname || "")} · ${entry.hits || 1} 次 · ${date}</span>
+        <button class="ghost" type="button" data-memory-key="${escapeHtml(entry.key)}">删除</button>
+      </li>`;
+  }).join("");
+}
+
+function setFieldMemoryFeedback(message, isError = false) {
+  if (!fields.fieldMemoryFeedback) {
+    return;
+  }
+  fields.fieldMemoryFeedback.textContent = message;
+  fields.fieldMemoryFeedback.classList.toggle("error", isError);
+}
+
+async function refreshFieldMemoryCard() {
+  const store = await getFieldMemory();
+  if (fields.fieldMemoryEnabled) {
+    fields.fieldMemoryEnabled.checked = store.enabled !== false;
+  }
+  const count = Object.keys(store?.entries || {}).length;
+  setFieldMemoryFeedback(
+    store.error
+      ? `读取字段记忆失败：${store.error}`
+      : store.enabled === false
+        ? `字段记忆已停用，当前保存 ${count} 条（不会被使用）。`
+        : `已启用，当前记住 ${count} 条字段映射。`
+  );
+  renderFieldMemoryList(store);
+}
+
+async function initFieldMemoryCard() {
+  if (!fields.fieldMemoryEnabled && !fields.fieldMemoryList) {
+    return;
+  }
+  fields.fieldMemoryEnabled?.addEventListener("change", async () => {
+    try {
+      await sendRuntimeMessage({ type: "OJAF_SET_FIELD_MEMORY_ENABLED", payload: { enabled: fields.fieldMemoryEnabled.checked } });
+      showToast(fields.fieldMemoryEnabled.checked ? "字段记忆已启用" : "字段记忆已停用");
+      await refreshFieldMemoryCard();
+    } catch (error) {
+      setFieldMemoryFeedback(`设置失败：${error.message}`, true);
+    }
+  });
+  fields.clearFieldMemoryButton?.addEventListener("click", async () => {
+    if (!window.confirm("清空全部字段记忆？此操作不可恢复。")) {
+      return;
+    }
+    try {
+      await sendRuntimeMessage({ type: "OJAF_CLEAR_FIELD_MEMORY" });
+      showToast("字段记忆已清空");
+      await refreshFieldMemoryCard();
+    } catch (error) {
+      setFieldMemoryFeedback(`清空失败：${error.message}`, true);
+    }
+  });
+  fields.fieldMemoryList?.addEventListener("click", async (event) => {
+    const button = event.target.closest("button[data-memory-key]");
+    if (!button) {
+      return;
+    }
+    try {
+      await sendRuntimeMessage({ type: "OJAF_DELETE_FIELD_MEMORY", payload: { key: button.dataset.memoryKey || "" } });
+      await refreshFieldMemoryCard();
+    } catch (error) {
+      setFieldMemoryFeedback(`删除失败：${error.message}`, true);
+    }
+  });
+  await refreshFieldMemoryCard();
+}
 
 window.addEventListener("beforeunload", (event) => {
   if (!profileHasUnsavedChanges && !apiHasUnsavedChanges) {

--- a/src/popup.html
+++ b/src/popup.html
@@ -19,8 +19,10 @@
 
       <section class="panel">
         <button id="startAutofillBtn" type="button">开始填写</button>
+        <button id="learnFromPageBtn" class="secondary" type="button">从本页学习</button>
         <button id="showProfilePanelBtn" class="secondary" type="button">打开资料面板</button>
         <button id="clearMarksBtn" class="ghost full" type="button">清除颜色标记</button>
+        <p class="hint">从本页学习：手动填完一页后点它，会把“你填的字段 → 资料字段”记进本机记忆，下次自动填。</p>
       </section>
 
       <section class="panel">

--- a/src/popup.js
+++ b/src/popup.js
@@ -2,6 +2,7 @@ const els = {
   status: document.getElementById("status"),
   openOptions: document.getElementById("openOptions"),
   startAutofillBtn: document.getElementById("startAutofillBtn"),
+  learnFromPageBtn: document.getElementById("learnFromPageBtn"),
   showProfilePanelBtn: document.getElementById("showProfilePanelBtn"),
   clearMarksBtn: document.getElementById("clearMarksBtn"),
   updateStatus: document.getElementById("updateStatus"),
@@ -15,6 +16,9 @@ const DEFAULT_CHECK_UPDATE_LABEL = els.checkUpdateBtn.textContent;
 els.openOptions.addEventListener("click", () => chrome.runtime.openOptionsPage());
 els.startAutofillBtn.addEventListener("click", () => {
   void startAutofill();
+});
+els.learnFromPageBtn?.addEventListener("click", () => {
+  void learnFromPage();
 });
 els.showProfilePanelBtn.addEventListener("click", () => {
   void showProfilePanel();
@@ -114,6 +118,40 @@ async function startAutofill() {
   } catch (error) {
     setStatus(`开始填写失败：${error.message}`, true);
     await syncRuntimeState({ updateStatus: false });
+  }
+}
+
+async function learnFromPage() {
+  const defaultLabel = els.learnFromPageBtn.textContent;
+  els.learnFromPageBtn.disabled = true;
+  els.learnFromPageBtn.textContent = "学习中...";
+  try {
+    const response = await sendToActiveTab({ type: "OJAF_LEARN_FROM_PAGE" });
+    const data = response?.data || {};
+    if (!data.ok) {
+      setStatus(data.reason || "从本页学习未完成。", true);
+      return;
+    }
+    const parts = [];
+    if (data.learned > 0) {
+      parts.push(`已学习 ${data.learned} 条映射（页面绿色标记 = 已学会的字段），下次遇到同名字段会自动填。`);
+    } else {
+      parts.push("没有学到新映射：页面上有值的字段要么重复出现被跳过，要么值不在资料库里。");
+    }
+    if (data.notInProfileCount > 0) {
+      const labels = (data.notInProfileLabels || []).join("、");
+      parts.push(`有 ${data.notInProfileCount} 个字段的值在资料库找不到（如 ${labels}）——把它们补进设置页资料库，学一次以后就能自动填。`);
+    }
+    if (data.ambiguousCount > 0) {
+      const labels = (data.ambiguousLabels || []).join("、");
+      parts.push(`${data.ambiguousCount} 个字段值匹配到多条资料无法确定（如 ${labels}），已跳过。`);
+    }
+    setStatus(parts.join(" "));
+  } catch (error) {
+    setStatus(`从本页学习失败：${error.message}`, true);
+  } finally {
+    els.learnFromPageBtn.disabled = false;
+    els.learnFromPageBtn.textContent = defaultLabel;
   }
 }
 


### PR DESCRIPTION
## 解决什么问题

网申表单里，「生源地」「籍贯」「毕业院校」「期望城市」这类字段在不同网站反复出现，但叫法零散：本地规则和 AI 不一定每次都认得出，同一个字段每次都要重新识别，甚至反复落到橙色待处理。

这个 PR 给 OpenJobAutofill 加上**字段记忆（Field Memory）**：填写成功一次，"页面字段标签 → 资料字段路径"的映射就记在本机；下次同名字段直接回填，不再消耗本地规则/AI 的识别，也减少待处理数量。

## 功能行为

- **自动学习**：「开始填写」中某字段自动填写成功（含"当前值已匹配"）→ 映射自动入记忆。
- **从本页学习**：弹窗新增按钮。用户手动填完一页后点击，读取页面当前值与本机资料库做归一化匹配，把映射写入记忆；值不在资料库的字段会列出名字，提示到设置页补录。
- **回填时机**：本地规则和 AI 都没有覆盖的字段，若标签命中记忆且对应资料字段仍有值，直接生成候选回填（confidence 0.95，mappingSource「字段记忆」）。
- **设置页管理**：启用开关、记忆条数、逐条删除、一键清空。

## 隐私与安全限制

与本项目隐私原则完全一致：

- 只记"字段标签 → 资料字段路径"映射 + 最近网站/成功次数，**不记任何资料值**。
- 同一页面出现 ≥2 次的同名字段（如多条教育经历的「学校」）不读也不写，避免错位。
- 记忆候选仍经过原有的语义兼容性检查（`isCategoryCompatibleForMapping` / `isSemanticallyIncompatible`），类别冲突会拒绝。
- 只补空缺，不覆盖本地规则 / AI 已有的匹配。
- 「从本页学习」跳过上传/附件/照片/密码类字段；多资料值歧义且标签无法定位时跳过并在弹窗报告。
- 容量上限 500 条，LRU 淘汰。

## 改动范围

6 个文件 +490 行，不改 manifest（无新增权限/文件），不改既有行为：

| 文件 | 改动 |
|---|---|
| `src/background.js` | `fieldMemoryV1` 存储 + 5 个消息处理 |
| `src/content.js` | 记忆候选合并、成功回写、`learnFromPage` |
| `src/popup.html` / `popup.js` | 「从本页学习」按钮与反馈 |
| `src/options.html` / `options.js` | 字段记忆管理卡片 |

已在多个国内招聘网站的网申表单上日常使用验证。

同一功能也以独立仓库形式发布（便于不等待合并直接使用）：
https://github.com/2011704037-bit/OpenJobAutofill-FieldMemory

如果对实现细节、命名或交互有不同意见，非常乐意按您的偏好调整。
